### PR TITLE
Install Vercel Web Analytics (#31)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,10 @@ export default [
   ...tseslint.configs.recommended,
 
   {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+
+  {
     plugins: {
       'simple-import-sort': simpleImportSort,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.4",
+        "@vercel/analytics": "^2.0.1",
         "framer-motion": "^12.38.0",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
@@ -1202,6 +1203,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "@vercel/analytics": "^2.0.1",
     "framer-motion": "^12.38.0",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/react';
 import React, { useEffect, useState } from 'react';
 
 import CSVUpload from './components/CSVUpload';
@@ -129,6 +130,7 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-bg flex flex-col">
+      <Analytics />
       <header className="border-b border-border py-6 text-center">
         <h1 className="font-display text-4xl font-normal text-text tracking-tight">
           CueMovie


### PR DESCRIPTION
Implemented Vercel Web Analytics for the watchlist-app project.

## Changes Made

### 1. Installed Dependencies
- Added `@vercel/analytics` (v2.0.1) package to the project
- Updated package-lock.json to reflect new dependency

### 2. Modified Files

**src/App.tsx**
- Added import for Analytics component from `@vercel/analytics/react`
- Placed `<Analytics />` component at the root of the main div, right after the opening tag
- This ensures analytics tracking is enabled across the entire application

**eslint.config.js**
- Added ignore patterns for `dist/**` and `node_modules/**` directories
- This prevents ESLint from checking build artifacts and dependencies
- Fixes linting errors that were occurring from checking compiled output

**package.json**
- Added `@vercel/analytics` as a production dependency

**package-lock.json**
- Updated with new dependency tree for @vercel/analytics and its sub-dependencies

## Implementation Details

Following the official Vercel Web Analytics quickstart guide (fetched from https://vercel.com/docs/analytics/quickstart), I implemented the React/Vite-specific setup:

1. Installed `@vercel/analytics` package using npm
2. Imported the Analytics component from `@vercel/analytics/react`
3. Added the `<Analytics />` component to the root of the application in App.tsx

The implementation is minimal and non-intrusive, preserving all existing code structure and functionality.

## Verification

- ✅ Build completed successfully (`npm run build`)
- ✅ Linter passes with no errors (`npm run lint`)
- ✅ TypeScript compilation successful
- ✅ All dependencies properly installed and locked

## Next Steps

Once this is deployed to Vercel:
1. Navigate to the Analytics section in the Vercel dashboard
2. Click "Enable" to activate tracking
3. Analytics data will start being collected automatically
4. Verify by checking the Network tab for analytics requests

No additional configuration or environment variables are required for basic functionality.