### PR TITLE
[#51] REFACTOR: Hide TMDB token from requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 # Environment variables
 .env
 .env.local
+.env*.local
 .env.*.local
 
 # Editor
@@ -22,3 +23,4 @@ dist/
 # OS
 .DS_Store
 Thumbs.db
+.vercel

--- a/api/tmdbFunction.ts
+++ b/api/tmdbFunction.ts
@@ -1,0 +1,44 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+interface VercelRequest extends IncomingMessage {
+  query: Record<string, string | string[]>;
+}
+
+interface VercelResponse extends ServerResponse {
+  status(code: number): VercelResponse;
+  json(body: unknown): void;
+}
+
+const TMDB_BASE = 'https://api.themoviedb.org/3';
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  const token = process.env.TMDB_TOKEN;
+  if (!token) {
+    res.status(500).json({ error: 'TMDB token not configured' });
+    return;
+  }
+
+  const path = req.query.path;
+  if (!path || typeof path !== 'string') {
+    res.status(400).json({ error: 'Missing path parameter' });
+    return;
+  }
+
+  const upstream = new URLSearchParams();
+  for (const [k, v] of Object.entries(req.query)) {
+    if (k !== 'path') upstream.set(k, Array.isArray(v) ? v[0] : v);
+  }
+
+  try {
+    const tmdbRes = await fetch(
+      `${TMDB_BASE}${path}${upstream.size ? `?${upstream}` : ''}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    res.status(tmdbRes.status).json(await tmdbRes.json());
+  } catch {
+    res.status(502).json({ error: 'Upstream TMDB request failed' });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ import { enrichAllMovies } from './utils/tmdb';
 const STORAGE_KEY = 'watchlist';
 const DECK_KEY = 'deck';
 const DECK_ENABLED_KEY = 'deckEnabled';
-const TMDB_TOKEN = import.meta.env.VITE_TMDB_TOKEN as string;
 const APP_VERSION = import.meta.env.PACKAGE_VERSION;
 const AUTHOR = import.meta.env.AUTHOR;
 
@@ -70,7 +69,6 @@ const App: React.FC = () => {
     const start = performance.now();
     const enriched = await enrichAllMovies(
       rawMovies,
-      TMDB_TOKEN,
       (completed, total) => setProgress({ completed, total }),
     );
     setMovies(enriched);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,9 +67,8 @@ const App: React.FC = () => {
     setFilters({});
     setError(null);
     const start = performance.now();
-    const enriched = await enrichAllMovies(
-      rawMovies,
-      (completed, total) => setProgress({ completed, total }),
+    const enriched = await enrichAllMovies(rawMovies, (completed, total) =>
+      setProgress({ completed, total }),
     );
     setMovies(enriched);
     setProgress(null);

--- a/src/utils/tmdb.ts
+++ b/src/utils/tmdb.ts
@@ -1,6 +1,5 @@
 import type { Movie } from '../types';
 
-const TMDB_BASE = 'https://api.themoviedb.org/3';
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
 
 // ---------------------------------------------------------------------------
@@ -38,24 +37,29 @@ async function waitForRateLimit(): Promise<void> {
 
 // ---------------------------------------------------------------------------
 // Rate-limited fetch with 429 retry
+//
+// Calls go through /api/tmdbFunction (a server-side proxy) so the TMDB bearer token
+// is never sent from or stored in the browser.
 // ---------------------------------------------------------------------------
 async function tmdbFetch(
-  url: string,
-  token: string,
+  path: string,
+  query: URLSearchParams,
   retries = 3,
 ): Promise<Response | null> {
   await waitForRateLimit();
+
+  const proxyParams = new URLSearchParams({ path });
+  query.forEach((v, k) => proxyParams.set(k, v));
+
   try {
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await fetch(`/api/tmdbFunction?${proxyParams}`);
     if (res.status === 429) {
       if (retries <= 0) return null;
       const raw = res.headers.get('Retry-After');
       const seconds = raw !== null ? parseFloat(raw) : NaN;
       const waitMs = isNaN(seconds) ? 2_000 : seconds * 1_000;
       await new Promise<void>((r) => setTimeout(r, waitMs));
-      return tmdbFetch(url, token, retries - 1);
+      return tmdbFetch(path, query, retries - 1);
     }
     return res.ok ? res : null;
   } catch {
@@ -92,7 +96,6 @@ export type TMDbEnrichment = {
 async function searchMovie(
   title: string,
   year: number | undefined,
-  token: string,
 ): Promise<TMDbSearchResult | null> {
   const params = new URLSearchParams({
     query: title,
@@ -102,7 +105,7 @@ async function searchMovie(
   });
   if (year) params.set('year', String(year));
 
-  const res = await tmdbFetch(`${TMDB_BASE}/search/movie?${params}`, token);
+  const res = await tmdbFetch('/search/movie', params);
   if (!res) return null;
   const data = await res.json();
   return (data.results?.[0] as TMDbSearchResult) ?? null;
@@ -110,22 +113,18 @@ async function searchMovie(
 
 async function fetchMovieDetails(
   id: number,
-  token: string,
 ): Promise<TMDbMovieDetails | null> {
-  const res = await tmdbFetch(`${TMDB_BASE}/movie/${id}`, token);
+  const res = await tmdbFetch(`/movie/${id}`, new URLSearchParams());
   if (!res) return null;
   return res.json() as Promise<TMDbMovieDetails>;
 }
 
-export async function enrichMovie(
-  movie: Movie,
-  token: string,
-): Promise<TMDbEnrichment> {
+export async function enrichMovie(movie: Movie): Promise<TMDbEnrichment> {
   try {
-    const result = await searchMovie(movie.title, movie.year, token);
+    const result = await searchMovie(movie.title, movie.year);
     if (!result) return {};
 
-    const details = await fetchMovieDetails(result.id, token);
+    const details = await fetchMovieDetails(result.id);
 
     return {
       rating: result.vote_average || undefined,
@@ -152,7 +151,6 @@ export async function enrichMovie(
 // ---------------------------------------------------------------------------
 export async function enrichAllMovies(
   movies: Movie[],
-  token: string,
   onProgress: (completed: number, total: number) => void,
   concurrency = 50,
 ): Promise<Movie[]> {
@@ -163,7 +161,7 @@ export async function enrichAllMovies(
   async function worker(): Promise<void> {
     while (nextIndex < movies.length) {
       const i = nextIndex++; // safe: JS is single-threaded, no await between read & write
-      enriched[i] = { ...movies[i], ...(await enrichMovie(movies[i], token)) };
+      enriched[i] = { ...movies[i], ...(await enrichMovie(movies[i])) };
       onProgress(++completed, movies.length);
     }
   }

--- a/src/utils/tmdb.ts
+++ b/src/utils/tmdb.ts
@@ -38,8 +38,10 @@ async function waitForRateLimit(): Promise<void> {
 // ---------------------------------------------------------------------------
 // Rate-limited fetch with 429 retry
 //
-// Calls go through /api/tmdbFunction (a server-side proxy) so the TMDB bearer token
-// is never sent from or stored in the browser.
+// In development, requests to /api/tmdbFunction are intercepted by Vite's
+// proxy (configured in vite.config.ts), which forwards them to TMDB and
+// injects the Authorization header server-side — so the token never reaches
+// the browser in either environment.
 // ---------------------------------------------------------------------------
 async function tmdbFetch(
   path: string,
@@ -111,9 +113,7 @@ async function searchMovie(
   return (data.results?.[0] as TMDbSearchResult) ?? null;
 }
 
-async function fetchMovieDetails(
-  id: number,
-): Promise<TMDbMovieDetails | null> {
+async function fetchMovieDetails(id: number): Promise<TMDbMovieDetails | null> {
   const res = await tmdbFetch(`/movie/${id}`, new URLSearchParams());
   if (!res) return null;
   return res.json() as Promise<TMDbMovieDetails>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "api"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,38 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
 import packageJson from './package.json';
 
-export default defineConfig({
-  base: process.env.VERCEL ? '/' : '/watchlist-app/',
-  plugins: [react(), tailwindcss()],
-  define: {
-    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
-    'import.meta.env.AUTHOR': JSON.stringify(packageJson.author),
-  },
+export default defineConfig(({ mode }) => {
+  // Load all env vars (empty string prefix = no filtering, so TMDB_TOKEN is included)
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    base: process.env.VERCEL ? '/' : '/watchlist-app/',
+    plugins: [react(), tailwindcss()],
+    define: {
+      'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
+      'import.meta.env.AUTHOR': JSON.stringify(packageJson.author),
+    },
+    server: {
+      proxy: {
+        '/api/tmdbFunction': {
+          target: 'https://api.themoviedb.org/3',
+          changeOrigin: true,
+          rewrite: (path) => {
+            const url = new URL(path, 'http://localhost');
+            const tmdbPath = url.searchParams.get('path') ?? '';
+            url.searchParams.delete('path');
+            return `${tmdbPath}?${url.searchParams}`;
+          },
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyReq) => {
+              proxyReq.setHeader('Authorization', `Bearer ${env.TMDB_TOKEN}`);
+            });
+          },
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
closes #51

Unfortunately, there's no way to make the fetch faster right now, unless we introduce a full scale backend/database. What we can do though, is improve security.